### PR TITLE
Fix Releases link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ brew install ogpk
 
 On linux:
 
-* Go to the [releases page](/releases) and download the latest release for your platform.
+* Go to the [releases page](https://github.com/almonk/ogpk/releases) and download the latest release for your platform.
 * Extract the archive and move the executable to a directory in your `PATH` (e.g. `/usr/local/bin`)
 * Make the executable executable, e.g.:
 


### PR DESCRIPTION
This is minor, but this fixes the "Releases" link in the README.

I tried to follow the Releases link in the README and it took me to this page instead:
```
https://github.com/almonk/ogpk/blob/main/releases
```

It seems that relative links in the Markdown files go to paths inside the repo and linking to special GitHub repo pages requires a [direct link][linking_to_releases].

[linking_to_releases]: https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases#linking-to-the-latest-release